### PR TITLE
feat: Add RlcPacketDropRateDl and PacketSuccessRateUlgNBUu KPM statis…

### DIFF
--- a/oai/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
+++ b/oai/openair2/E2AP/RAN_FUNCTION/O-RAN/ran_func_kpm.c
@@ -425,6 +425,7 @@ static const char* kpm_meas_du[] = {
   "DRB.UEThpUl",
   "RRU.PrbTotDl",
   "RRU.PrbTotUl",
+  "DRB.RlcPacketDropRateDl",
   NULL,
 };
 
@@ -436,6 +437,7 @@ static const char* kpm_meas_gnb[] = {
   "DRB.UEThpUl",
   "RRU.PrbTotDl",
   "RRU.PrbTotUl",
+  "DRB.PacketSuccessRateUlgNBUu",
   NULL,
 };
 


### PR DESCRIPTION
…tics

This commit adds the following KPM statistics:
- DRB.RlcPacketDropRateDl
- DRB.PacketSuccessRateUlgNBUu

The following changes were made:
- Added the new measurement names to `ran_func_kpm.c`
- Implemented the new measurement functions in `ran_func_kpm_subs.c`
- Added the new measurement functions to the `lst_measure` array in `ran_func_kpm_subs.c`